### PR TITLE
Added rule to ignore site placeholder images

### DIFF
--- a/app/code/EAVCleaner/Console/Command/RemoveUnusedMediaCommand.php
+++ b/app/code/EAVCleaner/Console/Command/RemoveUnusedMediaCommand.php
@@ -57,7 +57,7 @@ class RemoveUnusedMediaCommand extends Command
 
         foreach (new \RecursiveIteratorIterator($directoryIterator) as $file) {
 
-            if (strpos($file, "/cache") !== false || is_dir($file)) {
+            if (strpos($file, "/cache") !== false || strpos($file, "/placeholder") !== false || is_dir($file)) {
                 continue;
             }
 


### PR DESCRIPTION
A run of the images seemed to wipe placeholder images too - adding an exclusion rule so they can be skipped.